### PR TITLE
Fix gcc version detection on macOS

### DIFF
--- a/artifact.nix
+++ b/artifact.nix
@@ -38,6 +38,10 @@ let
           patchShebangs ghc*/configure
           sed -i 's@utils/ghc-pwd/dist-install/build/tmp/ghc-pwd-bindist@pwd@g' ghc*/configure
         '';
+
+        patches =
+          stdenv.lib.optional stdenv.isDarwin ./patches/ghc844/darwin-gcc-version-fix.patch;
+
         buildPhase = ''
           make show VALUE=ProjectVersion > version
         '';
@@ -114,6 +118,9 @@ stdenv.mkDerivation rec {
       sed -i "s|/usr/bin/perl|perl\x00        |" ghc*/ghc/stage2/build/tmp/ghc-stage2
       sed -i "s|/usr/bin/gcc|gcc\x00        |" ghc*/ghc/stage2/build/tmp/ghc-stage2
     '';
+
+  patches =
+    stdenv.lib.optional (version == "8.4.4" && stdenv.isDarwin) ./patches/ghc844/darwin-gcc-version-fix.patch;
 
   configurePlatforms = [ ];
   configureFlags = [

--- a/patches/ghc844/darwin-gcc-version-fix.patch
+++ b/patches/ghc844/darwin-gcc-version-fix.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -6184,7 +6184,7 @@ else
+ 
+     # Be sure only to look at the first occurrence of the "version " string;
+     # Some Apple compilers emit multiple messages containing this string.
+-    fp_cv_gcc_version="`$CC -v 2>&1 | sed -n -e '1,/version /s/.*version [^0-9]*\([0-9.]*\).*/\1/p'`"
++    fp_cv_gcc_version="`$CC -v 2>&1 | sed -n -e '1,/version /s/.*version [^0-9]*\([0-9.]*\).*/\1/p' | head -n 1`"
+     fp_version1=$fp_cv_gcc_version; fp_version2=4.4
+ fp_save_IFS=$IFS; IFS='.'
+ while test x"$fp_version1" != x || test x"$fp_version2" != x


### PR DESCRIPTION
On macOS with CUDA, it fails to build ghc-8.4.4 because of a problem on gcc version detection.

This PR applies a patch and makes it available.

This problem also blocks bootstrapping of `haskell.nix`.
Issue is open at https://github.com/input-output-hk/haskell.nix/issues/330 .


