### PR TITLE
Use `pkgs.lib` instead of `stdenv.lib`

### DIFF
--- a/artifact.nix
+++ b/artifact.nix
@@ -10,10 +10,10 @@ assert stdenv.targetPlatform == stdenv.hostPlatform;
 let
   host = hosts.${stdenv.targetPlatform.system};
 
-  libPath = stdenv.lib.makeLibraryPath ([
+  libPath = lib.makeLibraryPath ([
     selectedNcurses gmp
-  ] ++ stdenv.lib.optional (stdenv.hostPlatform.isDarwin) libiconv
-    ++ stdenv.lib.optional (stdenv.targetPlatform.isLinux) numactl);
+  ] ++ lib.optional (stdenv.hostPlatform.isDarwin) libiconv
+    ++ lib.optional (stdenv.targetPlatform.isLinux) numactl);
 
   ncursesVersion = host.ncursesVersion or "6";
 
@@ -42,7 +42,7 @@ let
     "8.0.1" = llvm_37;
   }."${bindistVersion}";
 
-  libEnvVar = stdenv.lib.optionalString stdenv.hostPlatform.isDarwin "DY"
+  libEnvVar = lib.optionalString stdenv.hostPlatform.isDarwin "DY"
     + "LD_LIBRARY_PATH";
 
   glibcDynLinker = assert stdenv.isLinux;
@@ -50,7 +50,7 @@ let
        # Could be stdenv.cc.bintools.dynamicLinker, keeping as-is to avoid rebuild.
        ''"$(cat $NIX_CC/nix-support/dynamic-linker)"''
     else
-      "${stdenv.lib.getLib glibc}/lib/ld-linux*";
+      "${lib.getLib glibc}/lib/ld-linux*";
 
   # Figure out version of bindist
   version =
@@ -66,7 +66,7 @@ let
         '';
 
         patches =
-          stdenv.lib.optional stdenv.isDarwin ./patches/ghc844/darwin-gcc-version-fix.patch;
+          lib.optional stdenv.isDarwin ./patches/ghc844/darwin-gcc-version-fix.patch;
 
         buildPhase = ''
           make show VALUE=ProjectVersion > version
@@ -90,8 +90,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ perl ];
   propagatedBuildInputs = [ stdenv.cc ]
-  ++ stdenv.lib.optionals (stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64) [ selectedLLVM ]
-  ++ stdenv.lib.optionals stdenv.targetPlatform.isLinux [ numactl ];
+  ++ lib.optionals (stdenv.targetPlatform.isAarch32 || stdenv.targetPlatform.isAarch64) [ selectedLLVM ]
+  ++ lib.optionals stdenv.targetPlatform.isLinux [ numactl ];
 
   # Cannot patchelf beforehand due to relative RPATHs that anticipate
   # the final install location/
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
   postUnpack =
     # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
     # during linking
-    stdenv.lib.optionalString stdenv.isDarwin ''
+    lib.optionalString stdenv.isDarwin ''
       export NIX_LDFLAGS+=" -no_dtrace_dof"
       # not enough room in the object files for the full path to libiconv :(
       for exe in $(find . -type f -executable); do
@@ -132,15 +132,15 @@ stdenv.mkDerivation rec {
     ''
       find . -name integer-gmp.buildinfo \
           -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${gmp.out}/lib@" {} \;
-    '' + stdenv.lib.optionalString stdenv.isDarwin ''
+    '' + lib.optionalString stdenv.isDarwin ''
       find . -name base.buildinfo \
           -exec sed -i "s@extra-lib-dirs: @extra-lib-dirs: ${libiconv}/lib@" {} \;
     '' +
     # Rename needed libraries and binaries, fix interpreter
     # N.B. Use patchelfUnstable due to https://github.com/NixOS/patchelf/pull/85
-    stdenv.lib.optionalString stdenv.isLinux ''
+    lib.optionalString stdenv.isLinux ''
       find . -type f -perm -0100 -exec ${patchelfUnstable}/bin/patchelf \
-          --replace-needed libncurses${stdenv.lib.optionalString stdenv.is64bit "w"}.so.${ncursesVersion} libncurses.so \
+          --replace-needed libncurses${lib.optionalString stdenv.is64bit "w"}.so.${ncursesVersion} libncurses.so \
           --replace-needed libtinfo.so.${ncursesVersion} libncurses.so.${ncursesVersion} \
           --interpreter ${glibcDynLinker} {} \;
 
@@ -149,14 +149,14 @@ stdenv.mkDerivation rec {
     '';
 
   patches =
-    stdenv.lib.optional (version == "8.4.4" && stdenv.isDarwin) ./patches/ghc844/darwin-gcc-version-fix.patch;
+    lib.optional (version == "8.4.4" && stdenv.isDarwin) ./patches/ghc844/darwin-gcc-version-fix.patch;
 
   configurePlatforms = [ ];
   configureFlags = [
-    "--with-gmp-libraries=${stdenv.lib.getLib gmp}/lib"
-    "--with-gmp-includes=${stdenv.lib.getDev gmp}/include"
-  ] ++ stdenv.lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
-    ++ stdenv.lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
+    "--with-gmp-libraries=${lib.getLib gmp}/lib"
+    "--with-gmp-includes=${lib.getDev gmp}/include"
+  ] ++ lib.optional stdenv.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
+    ++ lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
 
   # Stripping combined with patchelf breaks the executables (they die
   # with a segfault or the kernel even refuses the execve). (NIXPKGS-85)
@@ -168,14 +168,14 @@ stdenv.mkDerivation rec {
 
   # On Linux, use patchelf to modify the executables so that they can
   # find editline/gmp.
-  preFixup = stdenv.lib.optionalString stdenv.isLinux ''
+  preFixup = lib.optionalString stdenv.isLinux ''
     for p in $(find "$out" -type f -executable); do
       if isELF "$p"; then
         echo "Patchelfing $p"
         patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
       fi
     done
-  '' + stdenv.lib.optionalString stdenv.isDarwin ''
+  '' + lib.optionalString stdenv.isDarwin ''
     # not enough room in the object files for the full path to libiconv :(
     for exe in $(find "$out" -type f -executable); do
       isScript $exe && continue
@@ -214,6 +214,6 @@ stdenv.mkDerivation rec {
     haskellCompilerName = "ghc-${version}";
   };
 
-  meta.license = stdenv.lib.licenses.bsd3;
+  meta.license = lib.licenses.bsd3;
   meta.platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
 }


### PR DESCRIPTION
Fixes:

Warning: `stdenv.lib` is deprecated and will be removed in the next release. Please use `pkgs.lib` instead. For more information see https://github.com/NixOS/nixpkgs/issues/108938