### PR TITLE
Fix ncurses version for deb9

### DIFF
--- a/gen-hashes.nix
+++ b/gen-hashes.nix
@@ -18,7 +18,7 @@ for URL in ${concatStringsSep " " urls}; do
            esac)
     NCURSES=$(case ''${URL##*/} in
                 *deb8*)     echo "5";;
-                *deb9*)     echo "6";;
+                *deb9*)     echo "5";;
                 *fedora27*) echo "6";;
               esac)
     echo "  \"$NIXVER\".hosts.$HOST.src = { url = \"$URL\"; sha256 = \"$SHA\"; };"     >> hashes.nix

--- a/hashes.nix
+++ b/hashes.nix
@@ -7,7 +7,7 @@
   "ghc8107".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.7/ghc-8.10.7-x86_64-fedora27-linux.tar.xz"; sha256 = "0wsv3smj52jwwcp9pcl39vpfb5p1smv9jp768a04l193k826gvdn"; };
   "ghc8107".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc8107".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.10.7/ghc-8.10.7-i386-deb9-linux.tar.xz"; sha256 = "1ay5snnc9b4p5iib62dn52ws8n3ln5lwq4ccvb0a9rzljkqixz7v"; };
-  "ghc8107".hosts.i686-linux.ncursesVersion = "6";
+  "ghc8107".hosts.i686-linux.ncursesVersion = "5";
   "ghc8107".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.7/ghc-8.10.7-aarch64-deb10-linux.tar.xz"; sha256 = "0m8fklyqcd8xrmhwnimyhyg3b5h82kkc0yfyiazk6li9kdzl3lps"; };
   "ghc8106".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.10.6/ghc-8.10.6-x86_64-apple-darwin.tar.xz"; sha256 = "08ap1g3c0j5wrxb2fgz3q379j3qqi2m5rr6njwiawv6m0kd43arj"; };
   "ghc8106".version = "8.10.6";
@@ -16,7 +16,7 @@
   "ghc8106".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.6/ghc-8.10.6-x86_64-fedora27-linux.tar.xz"; sha256 = "1cfxir1yvggn731b744lc61jnvgdi79hzpclcr3prh6gcm2vhln4"; };
   "ghc8106".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc8106".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.10.6/ghc-8.10.6-i386-deb9-linux.tar.xz"; sha256 = "04qw1ywqqd048fhaiibq0m112p962mxzhg55x9ib8wbr7m139y9i"; };
-  "ghc8106".hosts.i686-linux.ncursesVersion = "6";
+  "ghc8106".hosts.i686-linux.ncursesVersion = "5";
   "ghc8106".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.6/ghc-8.10.6-aarch64-deb10-linux.tar.xz"; sha256 = "0ncali7pyh9k3hd2f4ks2zpjqvhpnlzb0bng3s4d1jz3frvpm8hy"; };
   "ghc8105".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.10.5/ghc-8.10.5-x86_64-apple-darwin.tar.xz"; sha256 = "08javwfqd21kglbr1bnhnbjw2cggz1n668vi8kx5hbcnz3plf3zg"; };
   "ghc8105".version = "8.10.5";
@@ -25,7 +25,7 @@
   "ghc8105".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.5/ghc-8.10.5-x86_64-fedora27-linux.tar.xz"; sha256 = "046ja9bn82wxk02881azc26q4r6p5c51mr9f0jlhmd8rnazqwlkk"; };
   "ghc8105".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc8105".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.10.5/ghc-8.10.5-i386-deb9-linux.tar.xz"; sha256 = "17cwmhhyz952psmp4j3pkdj0yrfxah3l2dawg5s4hdr228n5pjqc"; };
-  "ghc8105".hosts.i686-linux.ncursesVersion = "6";
+  "ghc8105".hosts.i686-linux.ncursesVersion = "5";
   "ghc8105".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.5/ghc-8.10.5-aarch64-deb10-linux.tar.xz"; sha256 = "1p0dgyn1m2nd8ax1g25lchaz9z2nk9jvyzf63biarq7qlzc5q24s"; };
   "ghc8104".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.10.4/ghc-8.10.4-x86_64-apple-darwin.tar.xz"; sha256 = "1mgn5qvg0iaxwa74zyn03ghqm811zmxckf0zb2iq2fz68djwypkj"; };
   "ghc8104".version = "8.10.4";
@@ -34,7 +34,7 @@
   "ghc8104".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.4/ghc-8.10.4-x86_64-fedora27-linux.tar.xz"; sha256 = "1sprvxv06j6z35gcgla2v656iad9p48gvfh6g5npswd803cyx2d1"; };
   "ghc8104".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc8104".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.10.4/ghc-8.10.4-i386-deb9-linux.tar.xz"; sha256 = "1bb9cla4ggfxhzrkxaqzs3na22zg5kcz6nklnjvmp0i2mjwwa8h0"; };
-  "ghc8104".hosts.i686-linux.ncursesVersion = "6";
+  "ghc8104".hosts.i686-linux.ncursesVersion = "5";
   "ghc8104".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.4/ghc-8.10.4-aarch64-deb10-linux.tar.xz"; sha256 = "1v9q81qcy6cx604gx05rmy2bj7khw7dbcy85zvpab6g71cqsd794"; };
   "ghc8103".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.10.3/ghc-8.10.3-x86_64-apple-darwin.tar.xz"; sha256 = "0590y9ckw03j7cv89xvi1z15r5qisa4swz6kvypnjkp4frfz6d96"; };
   "ghc8103".version = "8.10.3";
@@ -43,7 +43,7 @@
   "ghc8103".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.3/ghc-8.10.3-x86_64-fedora27-linux.tar.xz"; sha256 = "0nf1r29hiyi0zyd2r4yb7gppgbq5kngw7ipzm6vdc4l70099nwzq"; };
   "ghc8103".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc8103".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.10.3/ghc-8.10.3-i386-deb9-linux.tar.xz"; sha256 = "1cg7zsx52ph9nnshfmsmsg86nb9yvwyjqw78z67za1dp2qmdvbgh"; };
-  "ghc8103".hosts.i686-linux.ncursesVersion = "6";
+  "ghc8103".hosts.i686-linux.ncursesVersion = "5";
   "ghc8103".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.3/ghc-8.10.3-aarch64-deb10-linux.tar.xz"; sha256 = "1nxs3f4q3kh17rqp04jc8rv2vjdiiqb9sqy8rn3fh7ssa0nl6cd5"; };
   "ghc8102".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.10.2/ghc-8.10.2-x86_64-apple-darwin.tar.xz"; sha256 = "1hngyq14l4f950hzhh2d204ca2gfc98pc9xdasxihzqd1jq75dzd"; };
   "ghc8102".version = "8.10.2";
@@ -52,7 +52,7 @@
   "ghc8102".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.2/ghc-8.10.2-x86_64-fedora27-linux.tar.xz"; sha256 = "0frfai569kpx2h3040fplldg5hdjxgwva1xlxdj2yg4v7sl5srwc"; };
   "ghc8102".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc8102".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.10.2/ghc-8.10.2-i386-deb9-linux.tar.xz"; sha256 = "0bvwisl4w0z5z8z0da10m9sv0mhm9na2qm43qxr8zl23mn32mblx"; };
-  "ghc8102".hosts.i686-linux.ncursesVersion = "6";
+  "ghc8102".hosts.i686-linux.ncursesVersion = "5";
   "ghc8102".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.2/ghc-8.10.2-aarch64-deb10-linux.tar.xz"; sha256 = "14smwl3741ixnbgi0l51a7kh7xjkiannfqx15b72svky0y4l3wjw"; };
   "ghc8101".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.10.1/ghc-8.10.1-x86_64-apple-darwin.tar.xz"; sha256 = "1a5k8mmfb5cdxi0kcx2gz0hgf7lf2xl3w2z4lw24iplk20vcmcb5"; };
   "ghc8101".version = "8.10.1";
@@ -61,9 +61,9 @@
   "ghc8101".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.1/ghc-8.10.1-x86_64-fedora27-linux.tar.xz"; sha256 = "0w448jpbrk92cjbcihl87l95f3p3b0b5v3wyfdwmf10690mxfk1w"; };
   "ghc8101".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc8101".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.10.1/ghc-8.10.1-i386-deb9-linux.tar.xz"; sha256 = "1qkfd0y5vx6y53z2n6k9i2i6xmlx1hyaj819swsgdd97r3rfwlwb"; };
-  "ghc8101".hosts.i686-linux.ncursesVersion = "6";
+  "ghc8101".hosts.i686-linux.ncursesVersion = "5";
   "ghc8101".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.10.1/ghc-8.10.1-aarch64-deb9-linux.tar.xz"; sha256 = "1dsdm7rcpb5hiaz9kasn4mb5l1qzqf4mvywpwwbvk7cr0wg036f0"; };
-  "ghc8101".hosts.aarch64-linux.ncursesVersion = "6";
+  "ghc8101".hosts.aarch64-linux.ncursesVersion = "5";
   "ghc884".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.8.4/ghc-8.8.4-x86_64-apple-darwin.tar.xz"; sha256 = "0pnvrhrqgbafs0hd4c8p3i3c89r48dslna7khzfl3ywckng7h2p8"; };
   "ghc884".version = "8.8.4";
   "ghc884".nixversion = "ghc884";
@@ -71,9 +71,9 @@
   "ghc884".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.8.4/ghc-8.8.4-x86_64-fedora27-linux.tar.xz"; sha256 = "1nqmnlsbm20896ppd58rg0g55917vii2zq1safnlprq3mbw3fbpk"; };
   "ghc884".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc884".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.8.4/ghc-8.8.4-i386-deb9-linux.tar.xz"; sha256 = "1853bmyjzdyg08l1gdr20hni0kbpqymhmvrc66a7c0n9214rbpa3"; };
-  "ghc884".hosts.i686-linux.ncursesVersion = "6";
+  "ghc884".hosts.i686-linux.ncursesVersion = "5";
   "ghc884".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.8.4/ghc-8.8.4-aarch64-deb9-linux.tar.xz"; sha256 = ""; };
-  "ghc884".hosts.aarch64-linux.ncursesVersion = "6";
+  "ghc884".hosts.aarch64-linux.ncursesVersion = "5";
   "ghc883".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.8.3/ghc-8.8.3-x86_64-apple-darwin.tar.xz"; sha256 = "10mpvd4dk2y289a90y66v00sphl39ifrqxfhg7y0csr2vn8dw5kh"; };
   "ghc883".version = "8.8.3";
   "ghc883".nixversion = "ghc883";
@@ -81,9 +81,9 @@
   "ghc883".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.8.3/ghc-8.8.3-x86_64-fedora27-linux.tar.xz"; sha256 = "0668wy8vziwvpqnsqpm81a1d7qmda5vgqrbbi32br369pziivvj5"; };
   "ghc883".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc883".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.8.3/ghc-8.8.3-i386-deb9-linux.tar.xz"; sha256 = "1bh3a3cgjjc0qf57qnsl6dk7rnjwandr7g8jjwbvygn89xx2q7j4"; };
-  "ghc883".hosts.i686-linux.ncursesVersion = "6";
+  "ghc883".hosts.i686-linux.ncursesVersion = "5";
   "ghc883".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.8.3/ghc-8.8.3-aarch64-deb9-linux.tar.xz"; sha256 = "1ngf4y1ia6blqd3i592v869b1cxs9f9045w5f1vglv1jwz822s1a"; };
-  "ghc883".hosts.aarch64-linux.ncursesVersion = "6";
+  "ghc883".hosts.aarch64-linux.ncursesVersion = "5";
   "ghc882".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.8.2/ghc-8.8.2-x86_64-apple-darwin.tar.xz"; sha256 = "147r8xcxwhi09ffzhx45iy7b1zdd4q6w269b5grg7arn02kw3i95"; };
   "ghc882".version = "8.8.2";
   "ghc882".nixversion = "ghc882";
@@ -91,9 +91,9 @@
   "ghc882".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.8.2/ghc-8.8.2-x86_64-fedora27-linux.tar.xz"; sha256 = "07x27r688rddj2a0qpr4kldb5j9i59ylhphm1rwhyiikgdqxpqnv"; };
   "ghc882".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc882".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.8.2/ghc-8.8.2-i386-deb9-linux.tar.xz"; sha256 = "037hx22vzhrkdgpyb6w6gls4chma7vw7ynlh6sj3a9n3ha06475d"; };
-  "ghc882".hosts.i686-linux.ncursesVersion = "6";
+  "ghc882".hosts.i686-linux.ncursesVersion = "5";
   "ghc882".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.8.2/ghc-8.8.2-aarch64-deb9-linux.tar.xz"; sha256 = "1x2pfj9mnxac9rfki96bwwlmgi8ns0s7mhp99jmxkdm8726npdml"; };
-  "ghc882".hosts.aarch64-linux.ncursesVersion = "6";
+  "ghc882".hosts.aarch64-linux.ncursesVersion = "5";
   "ghc881".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.8.1/ghc-8.8.1-x86_64-apple-darwin.tar.xz"; sha256 = "1glapm42jkiwfzq6c0sp6n6qs6dy7b5dy1ckiksys6y38xxr3j1q"; };
   "ghc881".version = "8.8.1";
   "ghc881".nixversion = "ghc881";
@@ -101,9 +101,9 @@
   "ghc881".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.8.1/ghc-8.8.1-x86_64-fedora27-linux.tar.xz"; sha256 = "1mh4j8iba24p8ajsza1zk6af4map1l29fb159g1mdh0bcbgph6l5"; };
   "ghc881".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc881".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.8.1/ghc-8.8.1-i386-deb9-linux.tar.xz"; sha256 = "1xgp007l4cxdxlavy3phiwrbq7v8d0rlh46fgb49xmrdzxdbffrx"; };
-  "ghc881".hosts.i686-linux.ncursesVersion = "6";
+  "ghc881".hosts.i686-linux.ncursesVersion = "5";
   "ghc881".hosts.aarch64-linux.src = { url = "https://haskell.org/ghc/dist/8.8.1/ghc-8.8.1-aarch64-deb9-linux.tar.xz"; sha256 = "16ibbnrnxfsa4kiikkx1y56acpspw5fj6d8vadmvxqcwixhiq86l"; };
-  "ghc881".hosts.aarch64-linux.ncursesVersion = "6";
+  "ghc881".hosts.aarch64-linux.ncursesVersion = "5";
   "ghc865".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.6.5/ghc-8.6.5-x86_64-apple-darwin.tar.xz"; sha256 = "0s9188vhhgf23q3rjarwhbr524z6h2qga5xaaa2pma03sfqvvhfz"; };
   "ghc865".version = "8.6.5";
   "ghc865".nixversion = "ghc865";
@@ -111,7 +111,7 @@
   "ghc865".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.6.5/ghc-8.6.5-x86_64-fedora27-linux.tar.xz"; sha256 = "18dlqm5d028fqh6ghzn7pgjspr5smw030jjzl3kq6q1kmwzbay6g"; };
   "ghc865".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc865".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.6.5/ghc-8.6.5-i386-deb9-linux.tar.xz"; sha256 = "1p2h29qghql19ajk755xa0yxkn85slbds8m9n5196ris743vkp8w"; };
-  "ghc865".hosts.i686-linux.ncursesVersion = "6";
+  "ghc865".hosts.i686-linux.ncursesVersion = "5";
   "ghc864".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.6.4/ghc-8.6.4-x86_64-apple-darwin.tar.xz"; sha256 = "17mh9nmpch8hs2irm82hd9dp3xw9c2gq141nsw0vchgy8bqmijyc"; };
   "ghc864".version = "8.6.4";
   "ghc864".nixversion = "ghc864";
@@ -119,7 +119,7 @@
   "ghc864".hosts.x86_64-linux.src = { url = "https://haskell.org/ghc/dist/8.6.4/ghc-8.6.4-x86_64-fedora27-linux.tar.xz"; sha256 = "0imqsfd740yif0jvvc0bcprm9q7x6pnr44bskmgw7mkrlsksvcg0"; };
   "ghc864".hosts.x86_64-linux.ncursesVersion = "6";
   "ghc864".hosts.i686-linux.src = { url = "https://haskell.org/ghc/dist/8.6.4/ghc-8.6.4-i386-deb9-linux.tar.xz"; sha256 = "0b2mvb909n1ilsl9z6rm664h00f8a5xhr3i7gv1kmlhk9n7yhb2y"; };
-  "ghc864".hosts.i686-linux.ncursesVersion = "6";
+  "ghc864".hosts.i686-linux.ncursesVersion = "5";
   "ghc863".hosts.x86_64-darwin.src = { url = "https://haskell.org/ghc/dist/8.6.3/ghc-8.6.3-x86_64-apple-darwin.tar.xz"; sha256 = "1hbzk57v45176kxcx848p5jn5p1xbp2129ramkbzsk6plyhnkl3r"; };
   "ghc863".version = "8.6.3";
   "ghc863".nixversion = "ghc863";


### PR DESCRIPTION
It does seem like it needs to be 5 not 6